### PR TITLE
Edited GMN gmail address

### DIFF
--- a/src/layouts/Default.vue
+++ b/src/layouts/Default.vue
@@ -38,7 +38,7 @@
                             Discuss with us on <a href="https://matrix.to/#/#gmn-lobby:matrix.org">Matrix</a>
                             <br>
                             <i class="fab fa-envelope"></i>
-                            Email us at <a href="mailto:galaxy.mentoring@gmail.com">galaxy.mentoring@gmail.com</a>
+                            Email us at <a href="mailto:galaxy.mentorship@gmail.com">galaxy.mentorship@gmail.com</a>
                             <br>
                             <i class="fab fa-github"></i>
                             Check our <a href="https://github.com/galaxyproject/galaxy_mentor_network">GitHub repository</a>


### PR DESCRIPTION
## What did you do? 
- I edited the Gmail address, I caught the error
 


## Why did you make this change?
The correct Gmail address was galaxy.mentorship@gmail.com, an error was made initially in the footer.


## Have you tested locally?
(please check all three to move your PR forward!)
- [ ] I have tested the changes locally and they appear as I desire them to.
- [ ] I have tested the links and they work correctly.
- [ ] I have checked that the images match my expectations.


## How to test the changes? 
Instructions for manual testing are as follows:

1. Run `npm run develop`


## Add a screenshot if applicable
Not Applicable
